### PR TITLE
Add Tooling for flake8 and black

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,14 @@
+name: black
+
+on: [push, pull_request]
+
+jobs:
+  python-black:
+    name: Python Black
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Python Black
+        uses: cytopia/docker-black@0.8
+        with:
+          path: '.'

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,0 +1,25 @@
+name: flake8 
+
+on: [push, pull_request]
+
+jobs:
+  flake8_py3:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.9
+          architecture: x64
+      - name: Install flake8
+        run: |
+          pip install --upgrade pip
+          pip install -r REQUIREMENTS.qa.txt
+      - name: Run flake8
+        uses: suo/flake8-github-action@releases/v1
+        with:
+          checkName: 'flake8_py3'   # NOTE: this needs to be the same as the job name
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ env/
 venv/
 envs/
 dist/
+.idea

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PYTHON=python3
-
 PYTHON_ENV_ROOT=envs
 PYTHON_PACKAGING_VENV=$(PYTHON_ENV_ROOT)/$(PYTHON)-packaging-env
+PYTHON_TESTING_ENV=$(PYTHON_ENV_ROOT)/$(PYTHON)-qa-env
 
 .PHONY: clean
 
@@ -30,3 +30,19 @@ clean:
 	rm -rf $(PYTHON_ENV_ROOT)
 
 envs: env packaging-env
+
+
+# testing #####################################################################
+$(PYTHON_TESTING_ENV)/.created: REQUIREMENTS.qa.txt
+	rm -rf $(PYTHON_TESTING_ENV) && \
+	$(PYTHON) -m venv $(PYTHON_TESTING_ENV) && \
+	. $(PYTHON_TESTING_ENV)/bin/activate && \
+	pip install pip --upgrade && \
+	pip install -r ./REQUIREMENTS.qa.txt && \
+	date > $(PYTHON_TESTING_ENV)/.created
+
+qa: $(PYTHON_TESTING_ENV)/.created
+	. $(PYTHON_TESTING_ENV)/bin/activate && \
+	black --check --diff . && \
+	flake8
+

--- a/REQUIREMENTS.qa.txt
+++ b/REQUIREMENTS.qa.txt
@@ -1,0 +1,5 @@
+black
+flake8
+flake8-pyproject
+flake8-bugbear
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
 [tool.black]
 line-length = 119
 
+[tool.flake8]
+max-line-length = 119
+count = true
+exclude = "build,debian,dist,envs,fastentrypoints.py,__pycache__,usbmuxctl.egg-info,venv,contrib,setup.py"


### PR DESCRIPTION
This PR would add support for running `flake8` and `black` both locally and in Github Actions.

Locally we can simply run `make qa` and both tools will run.

On Github both tools run in Actions.
* `flake8`-messages are used to annotate the code pushed
* The `black`  action will only indicate if it would re-format any code.

See these examples for the Actions:
![Screenshot from 2023-07-01 17-25-31](https://github.com/linux-automation/usbmuxctl/assets/6676035/d001768e-c77d-494d-af90-7ccf5426ffd3)
![Screenshot from 2023-07-01 17-25-10](https://github.com/linux-automation/usbmuxctl/assets/6676035/697431bb-b668-4146-a186-5248ed7fa732)
