### PR TITLE
CI: add ruff linter / formattter / import sorter and codespell jobs

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,2 @@
+[codespell]
+skip = ./.git,./*.egg-info,./.pybuild,./build,./env,./venv,./envs,./dist

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -1,0 +1,11 @@
+name: Quality Assurance
+
+on: [push, pull_request]
+
+jobs:
+  ruff:
+    name: Python Format and Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: make qa-ruff

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -3,6 +3,13 @@ name: Quality Assurance
 on: [push, pull_request]
 
 jobs:
+  codespell:
+    name: Codespell
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: make qa-codespell
+
   ruff:
     name: Python Format and Lint
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ env/
 venv/
 envs/
 dist/
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 __pycache__
 *.egg-info
 /.pybuild
+/build/
 /debian/.debhelper/
 /debian/files
 /debian/usbmuxctl.debhelper.log
@@ -8,8 +9,8 @@ __pycache__
 /debian/usbmuxctl.prerm.debhelper
 /debian/usbmuxctl.substvars
 /debian/usbmuxctl/
-env/
-venv/
-envs/
-dist/
+/env/
+/venv/
+/envs/
+/dist/
 .idea

--- a/Makefile
+++ b/Makefile
@@ -38,12 +38,20 @@ $(PYTHON_TESTING_ENV)/.created:
 	$(PYTHON) -m venv $(PYTHON_TESTING_ENV) && \
 	. $(PYTHON_TESTING_ENV)/bin/activate && \
 	python3 -m pip install pip --upgrade && \
-	python3 -m pip install ruff && \
+	python3 -m pip install ruff codespell && \
 	date > $(PYTHON_TESTING_ENV)/.created
 
-.PHONY: qa qa-ruff qa-ruff-fix
+.PHONY: qa qa-codespell qa-codespell-fix qa-ruff qa-ruff-fix
 
-qa: qa-ruff
+qa: qa-codespell qa-ruff
+
+qa-codespell: $(PYTHON_TESTING_ENV)/.created
+	. $(PYTHON_TESTING_ENV)/bin/activate && \
+	codespell
+
+qa-codespell-fix: $(PYTHON_TESTING_ENV)/.created
+	. $(PYTHON_TESTING_ENV)/bin/activate && \
+	codespell -w
 
 qa-ruff: $(PYTHON_TESTING_ENV)/.created
 	. $(PYTHON_TESTING_ENV)/bin/activate && \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PYTHON=python3
-
 PYTHON_ENV_ROOT=envs
 PYTHON_PACKAGING_VENV=$(PYTHON_ENV_ROOT)/$(PYTHON)-packaging-env
+PYTHON_TESTING_ENV=$(PYTHON_ENV_ROOT)/$(PYTHON)-qa-env
 
 .PHONY: clean
 
@@ -30,3 +30,25 @@ clean:
 	rm -rf $(PYTHON_ENV_ROOT)
 
 envs: env packaging-env
+
+
+# testing #####################################################################
+$(PYTHON_TESTING_ENV)/.created:
+	rm -rf $(PYTHON_TESTING_ENV) && \
+	$(PYTHON) -m venv $(PYTHON_TESTING_ENV) && \
+	. $(PYTHON_TESTING_ENV)/bin/activate && \
+	python3 -m pip install pip --upgrade && \
+	python3 -m pip install ruff && \
+	date > $(PYTHON_TESTING_ENV)/.created
+
+.PHONY: qa qa-ruff qa-ruff-fix
+
+qa: qa-ruff
+
+qa-ruff: $(PYTHON_TESTING_ENV)/.created
+	. $(PYTHON_TESTING_ENV)/bin/activate && \
+	ruff format --check --diff && ruff check
+
+qa-ruff-fix: $(PYTHON_TESTING_ENV)/.created
+	. $(PYTHON_TESTING_ENV)/bin/activate && \
+	ruff format && ruff check --fix

--- a/README.rst
+++ b/README.rst
@@ -233,15 +233,16 @@ Thank you for considering a contribution to this project!
 Changes should be submitted via a
 `Github pull request <https://github.com/linux-automation/usbmuxctl/pulls>`_.
 
-We use the `black <https://black.readthedocs.io/en/stable/>`_ code formatter,
-please run `black` when contributing changes:
+We use the `ruff <https://docs.astral.sh/ruff/>`_ code formatter and linter,
+please run `ruff format` and `ruff check` when contributing changes:
 
 .. code-block:: bash
 
-    $ python3 -m pip install black
-    $ black *.py usbmuxctl/
-    All done! ✨ 🍰 ✨
-    8 files left unchanged.
+    $ python3 -m pip install ruff
+    $ ruff format
+    6 files left unchanged
+    $ ruff check
+    All checks passed!
 
 This project uses the `Developer's Certificate of Origin 1.1
 <https://developercertificate.org/>`_ with the same `process

--- a/fastentrypoints.py
+++ b/fastentrypoints.py
@@ -35,8 +35,10 @@ This is better.
 (c) 2016, Aaron Christianson
 http://github.com/ninjaaron/fast-entry_points
 """
-from setuptools.command import easy_install
+
 import re
+
+from setuptools.command import easy_install
 
 TEMPLATE = """\
 # -*- coding: utf-8 -*-
@@ -92,14 +94,14 @@ def main():
         with open(manifest_path, "a+") as manifest:
             manifest.seek(0)
             manifest_content = manifest.read()
-            if not "include fastentrypoints.py" in manifest_content:
+            if "include fastentrypoints.py" not in manifest_content:
                 manifest.write(("\n" if manifest_content else "") + "include fastentrypoints.py")
 
         # Insert the import statement to setup.py if not present
         with open(setup_path, "a+") as setup:
             setup.seek(0)
             setup_content = setup.read()
-            if not "import fastentrypoints" in setup_content:
+            if "import fastentrypoints" not in setup_content:
                 setup.seek(0)
                 setup.truncate()
                 setup.write("import fastentrypoints\n" + setup_content)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,18 @@
-[tool.black]
+[tool.ruff]
 line-length = 119
+exclude = [
+  "fastentrypoints.py",
+  "__pycache__",
+  "usbmuxctl.egg-info",
+  ".pybuild",
+  "build",
+  "debian",
+  "env",
+  "venv",
+  "setup.py",
+  "envs",
+  "dist",
+]
 
+[tool.ruff.lint]
+select = ["B", "E", "F", "I", "SIM"]

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import fastentrypoints
 
 from setuptools import setup
 

--- a/usbmuxctl/__main__.py
+++ b/usbmuxctl/__main__.py
@@ -389,7 +389,7 @@ def software_update(args):
             if err.errno == errno.EACCES:
                 result["error"] = True
                 result["errormessage"] = (
-                    "'dfu-util' failed. This probably happend because of "
+                    "'dfu-util' failed. This probably happened because of "
                     + f"insufficient permissions: {err} "
                     + "Disconnect and reconnect the USB-Mux."
                 )

--- a/usbmuxctl/__main__.py
+++ b/usbmuxctl/__main__.py
@@ -35,9 +35,7 @@ class ConnectionNotPossible(Exception):
 
 
 artwork = {}
-artwork[
-    "DUT-Host Device-Host"
-] = """                                     +-----------------------+
+artwork["DUT-Host Device-Host"] = """                                     +-----------------------+
                                      | USB-Mux               |
                                   +--|                       |
                                   |  | SN:   {:11s}     |
@@ -51,9 +49,7 @@ Host |>--------------|       1 |--+         ID: {}
                      |       3 |---------------------|> Device
                      +---------+           VCC: {:1.2f}V"""
 
-artwork[
-    "None"
-] = """                                     +-----------------------+
+artwork["None"] = """                                     +-----------------------+
                                      | USB-Mux               |
                                   +--|                       |
                                   |  | SN:   {:11s}     |
@@ -67,9 +63,7 @@ Host |>--------------|       1 |--+         ID: {}
                      |       3 |----x    ------------|> Device
                      +---------+           VCC: {:1.2f}V"""
 
-artwork[
-    "DUT-Host"
-] = """                                     +-----------------------+
+artwork["DUT-Host"] = """                                     +-----------------------+
                                      | USB-Mux               |
                                   +--|                       |
                                   |  | SN:   {:11s}     |
@@ -83,9 +77,7 @@ Host |>--------------|       1 |--+         ID: {}
                      |       3 |----x    ------------|> Device
                      +---------+           VCC: {:1.2f}V"""
 
-artwork[
-    "Device-Host"
-] = """                                     +-----------------------+
+artwork["Device-Host"] = """                                     +-----------------------+
                                      | USB-Mux               |
                                   +--|                       |
                                   |  | SN:   {:11s}     |
@@ -99,9 +91,7 @@ Host |>--------------|       1 |--+         ID: {}
                      |       3 |---------------------|> Device
                      +---------+           VCC: {:1.2f}V"""
 
-artwork[
-    "DUT-Device"
-] = """                                     +-----------------------+
+artwork["DUT-Device"] = """                                     +-----------------------+
                                      | USB-Mux               |
                                   +--|                       |
                                   |  | SN:   {:11s}     |
@@ -392,9 +382,9 @@ def software_update(args):
             result["errormessage"] = "Failed to connect to device: Failed to find the defined USB-Mux"
         except DfuUtilNotFoundError:
             result["error"] = True
-            result[
-                "errormessage"
-            ] = "Could not find tool 'dfu-util'. Please install using your package manager and re-run this command."
+            result["errormessage"] = (
+                "Could not find tool 'dfu-util'. Please install using your package manager and re-run this command."
+            )
         except DfuUtilFailedError as e:
             result["error"] = True
             result["errormessage"] = f"'dfu-util' failed: '{e}'. Please check the log above for hints how to fix this."

--- a/usbmuxctl/__main__.py
+++ b/usbmuxctl/__main__.py
@@ -176,10 +176,7 @@ def list_usb(args):
         for d in Mux.find_devices():
             mux = Mux(path=d["path"])
             status = mux.get_status()
-            if status["data_links"] == "":
-                connections = "None"
-            else:
-                connections = status["data_links"]
+            connections = status["data_links"] if status["data_links"] != "" else "None"
             lock = "locked" if status["dut_power_lockout"] else "unlocked"
 
             messages = _ui_messages(status)

--- a/usbmuxctl/update.py
+++ b/usbmuxctl/update.py
@@ -359,8 +359,8 @@ def dfu_util_version():
         dfu_version, *_ = output.split("\n")
 
         return dfu_version
-    except FileNotFoundError:
-        raise DfuUtilNotFoundError("dfu-util not found. Might not be installed.")
+    except FileNotFoundError as e:
+        raise DfuUtilNotFoundError("dfu-util not found. Might not be installed.") from e
 
 
 def dfu_util_flash_firmware(firmware_path, usb_path):
@@ -371,15 +371,15 @@ def dfu_util_flash_firmware(firmware_path, usb_path):
     firmware_path -- Path to the firmware file as string
     usb_path      -- USB path to USB device (example: 1-2.2.1)
 
-    Throws an Exception if dfu-util is not installed oder dfu-util failed"""
+    Throws an Exception if dfu-util is not installed or dfu-util failed"""
     try:
         res = subprocess.run(
             [DFU_UTIL_CMD, "-d", "0483:df11", "-a", "0", "-D", firmware_path, "-s", "0x8000000", "--path", usb_path]
         )
         if res.returncode != 0:
             raise DfuUtilFailedError(f"dfu-util failed with: {res}")
-    except FileNotFoundError:
-        raise DfuUtilNotFoundError("dfu-util not found. Might not be installed.")
+    except FileNotFoundError as e:
+        raise DfuUtilNotFoundError("dfu-util not found. Might not be installed.") from e
 
 
 def dfu_util_flash_config(file_path, usb_path):
@@ -390,15 +390,15 @@ def dfu_util_flash_config(file_path, usb_path):
     firmware_path -- Path to the config file as string
     usb_path      -- USB path to USB device (example: 1-2.2.1)
 
-    Throws an Exception if dfu-util is not installed oder dfu-util failed"""
+    Throws an Exception if dfu-util is not installed or dfu-util failed"""
     try:
         res = subprocess.run(
             [DFU_UTIL_CMD, "-d", "0483:df11", "-a", "0", "-D", file_path, "-s", "0x8007c00", "--path", usb_path]
         )
         if res.returncode != 0:
             raise Exception(f"dfu-util failed with: {res}")
-    except FileNotFoundError:
-        raise Exception("dfu-util not found. Might not be installed.")
+    except FileNotFoundError as e:
+        raise Exception("dfu-util not found. Might not be installed.") from e
 
 
 def _find_dfu_device(search_path):

--- a/usbmuxctl/update.py
+++ b/usbmuxctl/update.py
@@ -201,7 +201,7 @@ class DFU:
 
     def _check_status(self):
         """Wrapper for _get_status.
-        Returns the device status and thows DFUException if bStatus is not OK"""
+        Returns the device status and throws DFUException if bStatus is not OK"""
 
         status = self._get_status()
         if status["bStatus"] != _bStatus.OK:
@@ -226,7 +226,7 @@ class DFU:
     def _set_address(self, address):
         """DFU internal command
         Set the address to read, write, execute"""
-        self.log.debug("Set Adress: %x", address)
+        self.log.debug("Set Address: %x", address)
         self._cmd_out(_DfuCommand.DFU_DNLOAD, 0, struct.pack("<BI", 0x21, address))
         self._check_status()
 
@@ -238,12 +238,12 @@ class DFU:
 
         ret = self._cmd_in(_DfuCommand.DFU_UPLOAD, 2, length)
 
-        self.log.debug("Data receving: %s", "".join(f"{i:02X}" for i in ret))
+        self.log.debug("Data receiving: %s", "".join(f"{i:02X}" for i in ret))
         return ret, self._check_status()
 
     def _get_cmd(self):
         """DFU internal command
-        Requests a list of supportet commands from the DFU device"""
+        Requests a list of supported commands from the DFU device"""
         raise NotImplementedError()
 
     def _write_mem(self):
@@ -267,7 +267,7 @@ class DFU:
         status = self._check_status()
 
         if status["bState"] != _bState.dfuMANIFEST:
-            self.log.error("Leave dfu command faild")
+            self.log.error("Leave dfu command failed")
             raise DFUException(status)
 
     def read_at_addr_len(self, addr, length):
@@ -500,7 +500,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--serial",
         "-s",
-        help="USBMux serial numer (00001.00020)",
+        help="USBMux serial number (00001.00020)",
     )
     parser.add_argument(
         "-v",

--- a/usbmuxctl/usbmuxctl.py
+++ b/usbmuxctl/usbmuxctl.py
@@ -18,6 +18,7 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
+import contextlib
 import errno
 import struct
 from sys import stderr
@@ -177,8 +178,8 @@ class Mux:
                 raise ProtocolVersionMismatch(
                     "The protocol version reported by the USB-Mux is not supported by this control tool."
                 )
-        except ValueError:
-            raise NoPrivileges("Could not communicate with USB-device. Check privileges, maybe add udev-rule")
+        except ValueError as e:
+            raise NoPrivileges("Could not communicate with USB-device. Check privileges, maybe add udev-rule") from e
 
         # read sw version
         self.sw_version = str(self._send_cmd(self._SW_VERSION), "utf-8")
@@ -296,10 +297,8 @@ class Mux:
         self._connect_data(0)
 
         sleep(0.1)
-        try:
+        with contextlib.suppress(usb.core.USBError):
             self._send_cmd(self._DFU)
-        except usb.core.USBError:
-            pass
 
     def connect(self, links, id_pull_low=None):
         """
@@ -350,7 +349,7 @@ class Mux:
         return path
 
     def is_software_up_to_date(self):
-        return version.FIRMWARE_VERSION <= self.sw_version_num
+        return self.sw_version_num >= version.FIRMWARE_VERSION
 
     def update_software(self):
         """Updates the usbmux software"""

--- a/usbmuxctl/usbmuxctl.py
+++ b/usbmuxctl/usbmuxctl.py
@@ -75,7 +75,7 @@ class Mux:
             "PRODUCTID": 0x0001,
         },
         {
-            # This is a _fake_ Vendor-ID and Product-ID that we have choosen by throwing dice during
+            # This is a _fake_ Vendor-ID and Product-ID that we have chosen by throwing dice during
             # development. This ID is only for the transition phase. There should be no USB-Muxes
             # in the wild using this ID!
             "VENDORID": 0x5824,


### PR DESCRIPTION
This PR is based on #6 and intended to replace it.

This changes the recommended auto formatter from `black` to `ruff`. The main benefit of this change is that `ruff` also includes a linter and an import sorter, that do not need configuration to work together without fighting.

The linter and import sorting features of `ruff` are then used to and added to the CI to make sure that best practices are followed in all pull requests.

Lastly this also adds a CI job that runs codespell to fix new typos from entering the codebase.