### PR TITLE
pyproject.toml: use setuptools_scm to determine version number

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,6 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # include tags and full history for setuptools_scm
+          fetch-depth: 0
       - run: make build
       - uses: actions/upload-artifact@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,10 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools", "setuptools_scm[toml]"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "usbmuxctl"
 description = "Tool to control an USB-Mux from the command line"
-version = "0.1.3"
 authors = [
   { name = "Chris Fiege", email = "python@pengutronix.de" },
 ]
@@ -21,6 +20,7 @@ classifiers = [
     "Operating System :: Unix",
     "Programming Language :: Python :: 3 :: Only"
 ]
+dynamic = ["version"] # via setuptools_scm
 
 [project.urls]
 homepage="https://github.com/linux-automation/usbmuxctl"
@@ -35,6 +35,9 @@ packages = [
   "usbmuxctl.firmware"
 ]
 include-package-data = true
+
+[tool.setuptools_scm]
+local_scheme = "no-local-version"
 
 [tool.ruff]
 line-length = 119


### PR DESCRIPTION
This means we no longer have to update the version number manually when creating a new release because just setting a tag suffices.

It does however also add some complexity and magic to the project, like incorrect version numbers when the git history is not complete (hence why we now clone the whole history in the build job) and all files included in the git repository now being shipped in the source distribution (while previously only files mentioned in the `MANIFEST.in` were included).

The beneftis when it comes to automating the release process do however outweight the drawbacks of added compexity.

We use `local_scheme = "no-local-version"` to prevent random files in the project directory from causing `+dirty` version numbers.

Thus use `setuptools_scm` to determine the version number from git tags.

See linux-automation/lxa-iobus#44 for an equivalent PR for another project.